### PR TITLE
Setup deployment to a server with SSH using GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd /path/to/your/project
+            git pull origin main
+            docker-compose down
+            docker-compose up -d --build

--- a/README.md
+++ b/README.md
@@ -65,3 +65,23 @@ The backend is built with Express.js and includes several intentionally transpar
 ## Disclaimer
 
 This application intentionally contains vulnerabilities for educational purposes. Do not use any code from this project in production systems or real election applications.
+
+## Deployment
+
+To set up the deployment environment variables and secrets for GitHub Actions, follow these steps:
+
+1. Go to your GitHub repository and click on `Settings`.
+2. In the left sidebar, click on `Secrets` and then `Actions`.
+3. Click on the `New repository secret` button to add the following secrets:
+   - `SSH_HOST`: The hostname or IP address of your server.
+   - `SSH_USER`: The SSH username to connect to your server.
+   - `SSH_KEY`: The private SSH key to authenticate with your server.
+   - `SSH_PORT`: The SSH port (default is 22, but change if your server uses a different port).
+
+Once these secrets are set up, the GitHub Actions workflow will use them to deploy the application to your server.
+
+### Server
+
+Setup a compute note in GCP/Azure/AWS with SSH.
+
+Connect to Cloudflare for domain handling.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Once these secrets are set up, the GitHub Actions workflow will use them to depl
 
 ### Server
 
-Setup a compute note in GCP/Azure/AWS with SSH.
+Setup a compute node in GCP/Azure/AWS with SSH.
 
 Connect to Cloudflare for domain handling.


### PR DESCRIPTION
Add GitHub Actions workflow for deployment to a server using SSH.

* **Workflow Configuration**
  - Create `.github/workflows/deploy.yml` to define the deployment workflow.
  - Trigger the workflow on push events to the main branch.
  - Use `webfactory/ssh-agent` to set up SSH with the private key from secrets.
  - Use `appleboy/ssh-action` to execute SSH commands for deployment.

* **Deployment Steps**
  - Checkout code.
  - Set up SSH.
  - Deploy to server by navigating to the project directory, pulling the latest code, and restarting the Docker containers.

* **README Update**
  - Add instructions for setting up deployment environment variables and secrets in GitHub repository settings.
  - Include steps to add `SSH_HOST`, `SSH_USER`, `SSH_KEY`, and `SSH_PORT` secrets.
  - Provide guidance on setting up a compute node in GCP/Azure/AWS with SSH and connecting to Cloudflare for domain handling.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HNygard/election-demo/pull/4?shareId=ce411c3e-3b52-4a9d-9317-6a23127eaccf).